### PR TITLE
Add Linter to Codebase

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,29 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: Lint Code Base
+
+on:
+  push:
+    branches: [ "testing", "release-candidate", "installer-v2" ]
+  pull_request:
+    branches: [ "testing", "release-candidate", "installer-v2" ]
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: "main"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a proposal to add a code linter for the following branches:

- testing
- release-candidate
- installer-v2

This linter works across multiple programming languages (including bash), and will help keep the code clean. This change would best work if it's added to the main branch first, and then the other branches sync their copies. The main branch linter won't be as active, because the code is checked by both the `release-candidate` linter and the `testing` linter, which gets automatically merged to the main branch.